### PR TITLE
[class-methods-use-this] Do not force that class methods use "this"

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,5 +15,8 @@ module.exports = {
     // to use "foo" because it makes such and such easier
     // without adding unnecessary complexity.
     // 'no-foo': 'off',
+
+    // This makes class inheritance annoying sometimes.
+    'class-methods-use-this': 'off',
   },
 };


### PR DESCRIPTION
Abstracting out class methods which don't access "this" into static methods is more DRY, however it can make class inheritance difficult sometimes.

[`class-methods-use-this` on ESLint](https://eslint.org/docs/rules/class-methods-use-this).
