### PR TITLE
[no-underscore-dangle] Allow underscore dangling

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,5 +15,13 @@ module.exports = {
     // to use "foo" because it makes such and such easier
     // without adding unnecessary complexity.
     // 'no-foo': 'off',
+
+    // We like differentiating private methods and variables
+    // by prepending an underscore. Although there is no
+    // concept of "private" properties in JavaScript, it's
+    // still a useful nomenclature that allows developers
+    // and users alike to know which properties they should
+    // and should not access.
+    'no-underscore-dangle': 'off',
   },
 };


### PR DESCRIPTION
We like differentiating private methods and variables by prepending an underscore. Although there is no concept of "private" properties in JavaScript, it's still a useful nomenclature that allows developers and users alike to know which properties they should and should not access.

[`no-underscore-dangle` on ESLint](https://eslint.org/docs/rules/no-underscore-dangle).
