### PR TITLE
v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-  - '8'
-  - '9'
-  - '10'
   - 'node'
   - 'lts/*'
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - 'node'
-  - 'lts/*'
+  - "node"
+  - "lts/*"
 deploy:
   - provider: npm
     email: "api@hellosign.com"

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ In your ESLint configuration (probably an `.eslintrc` file), add:
 
 ### Atom
 
-Install [`linter-eslint`](https://atom.io/packages/linter-eslint). To fix files automatically, bring up the command palette (<kbd>⬆</kbd> + <kbd>⌘</kbd> + <kbd>p</kbd>) and choose `Linter Eslint: Fix File`.
+Install [`linter-eslint`](https://atom.io/packages/linter-eslint). To fix files automatically, bring up the command palette (<kbd>shift</kbd><kbd>cmd</kbd><kbd>p</kbd>) and choose `Linter Eslint: Fix File`.
 
 ### Sublime Text 3
 
-Install [`SublimeLinter-eslint`](https://github.com/roadhump/SublimeLinter-eslint) and [`ESLint-Formatter`](https://github.com/TheSavior/ESLint-Formatter). To fix files automatically, use the shortcut <kbd>⬆</kbd> + <kbd>⌘</kbd> + <kbd>h</kbd>, or choose `ESLint Formatter: Format this file` from the command palette.
+Install [`SublimeLinter-eslint`](https://github.com/roadhump/SublimeLinter-eslint) and [`ESLint-Formatter`](https://github.com/TheSavior/ESLint-Formatter). To fix files automatically, use the shortcut <kbd>shift</kbd><kbd>cmd</kbd><kbd>h</kbd>, or choose `ESLint Formatter: Format this file` from the command palette.
 
 ### Others
 

--- a/index.js
+++ b/index.js
@@ -15,5 +15,16 @@ module.exports = {
     // to use "foo" because it makes such and such easier
     // without adding unnecessary complexity.
     // 'no-foo': 'off',
+
+    // This makes class inheritance annoying sometimes.
+    'class-methods-use-this': 'off',
+
+    // We like differentiating private methods and variables
+    // by prepending an underscore. Although there is no
+    // concept of "private" properties in JavaScript, it's
+    // still a useful nomenclature that allows developers
+    // and users alike to know which properties they should
+    // and should not access.
+    'no-underscore-dangle': 'off',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config",
+  "name": "@hellosign/eslint-config",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellosign/eslint-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hellosign/eslint-config",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint shareable config by HelloSign",
   "main": "index.js",
   "author": "HelloSign",


### PR DESCRIPTION
* Allows underscore dangling ([`no-underscore-dangle`](https://eslint.org/docs/rules/no-underscore-dangle))
* Allows class methods to omit `this` ([`class-methods-use-this`](https://eslint.org/docs/rules/class-methods-use-this))